### PR TITLE
Add LongWriter-V

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,6 +997,10 @@ Engineering.**](https://doi.org/10.48550/arXiv.2410.07095) *Jun Shern Chan, Neil
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [![GitHub Repo stars](https://img.shields.io/github/stars/stanfordmlgroup/ManyICL)](https://github.com/stanfordmlgroup/ManyICL)
 
+3. [**LongWriter-V: Enabling Ultra-Long and High-Fidelity Generation in Vision-Language Models.**](https://arxiv.org/abs/2502.14834) *Shangqing Tu, Yucheng Wang, Daniel Zhang-Li, Yushi Bai, Jifan Yu, Yuhao Wu, Lei Hou, Huiqin Liu, Zhiyuan Liu, Bin Xu, Juanzi Li.* Arxiv 2025.
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [![GitHub Repo stars](https://img.shields.io/github/stars/THU-KEG/LongWriter-V)](https://github.com/THU-KEG/LongWriter-V)
+
 
 #### Specific Domains
 


### PR DESCRIPTION
Hi, Thanks for your great survey! I have added one paper (LongWriter-V) to the multimodal application section. This paper trains VLMs to produce high-fidelity outputs of up to 10,000 words, significantly enhancing their capabilities in tasks like creative writing, professional report generation, and comprehensive analysis based on visual inputs. 
Wish you can add this paper. Thank you!