### PR TITLE
add yoro paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,11 @@ Checkpoints.**](https://doi.org/10.18653/v1/2023.emnlp-main.298) *Joshua Ainslie
 1. [**MemoryBank: Enhancing Large Language Models with Long-Term Memory.**](https://arxiv.org/abs/2305.10250) *Wanjun Zhong, Lianghong Guo, Qiqi Gao, He Ye, Yanlin Wang.* Arxiv 2023.  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [![GitHub Repo stars](https://img.shields.io/github/stars/zhongwanjun/MemoryBank-SiliconFriend)](https://github.com/zhongwanjun/MemoryBank-SiliconFriend)
 
+#### Parametric Memory
+
+1. [**You Only Read Once (YORO): Learning to Internalize Database Knowledge for Text-to-SQL.**](https://aclanthology.org/2025.naacl-long.94/) Hideo Kobayashi, Wuwei Lan, Peng Shi, Shuaichen Chang, Jiang Guo, Henghui Zhu, Zhiguo Wang, Patrick Ng. NAACL 2025
+
+
 #### RAG-Based
 
 1. [**{BERT}: Pre-training of Deep Bidirectional Transformers for Language Understanding.**](https://aclanthology.org/N19-1423/) *Jacob Devlin, Ming-Wei Chang, Kenton Lee, Kristina Toutanova*. ACL 2019

--- a/README.md
+++ b/README.md
@@ -765,8 +765,6 @@ Checkpoints.**](https://doi.org/10.18653/v1/2023.emnlp-main.298) *Joshua Ainslie
 1. [**MemoryBank: Enhancing Large Language Models with Long-Term Memory.**](https://arxiv.org/abs/2305.10250) *Wanjun Zhong, Lianghong Guo, Qiqi Gao, He Ye, Yanlin Wang.* Arxiv 2023.  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; [![GitHub Repo stars](https://img.shields.io/github/stars/zhongwanjun/MemoryBank-SiliconFriend)](https://github.com/zhongwanjun/MemoryBank-SiliconFriend)
 
-#### Parametric Memory
-
 1. [**You Only Read Once (YORO): Learning to Internalize Database Knowledge for Text-to-SQL.**](https://aclanthology.org/2025.naacl-long.94/) Hideo Kobayashi, Wuwei Lan, Peng Shi, Shuaichen Chang, Jiang Guo, Henghui Zhu, Zhiguo Wang, Patrick Ng. NAACL 2025
 
 


### PR DESCRIPTION
Hi authors, Thanks for your great survey! I added our recent NAACL 2025 paper.

Paper title: You Only Read Once (YORO): Learning to Internalize Database Knowledge for Text-to-SQL
Paper link: https://aclanthology.org/2025.naacl-long.94.pdf

TL;DR This paper will fit into **4.2. Memory-Based Methods** -> **Parametric Memory paragraph** in your paper. YORO internalizes the database schema (=long context) in input prompts into parametric knowledge of LMs via fine-tuning. It significantly reduces the input token length by 66%-98%. 